### PR TITLE
Add cmake projects integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ project(hyprwayland-scanner
 )
 
 include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
 
 set(PREFIX ${CMAKE_INSTALL_PREFIX})
 
@@ -42,6 +43,14 @@ file(GLOB_RECURSE SRCFILES CONFIGURE_DEPENDS "src/*.cpp")
 add_executable(hyprwayland-scanner ${SRCFILES})
 target_link_libraries(hyprwayland-scanner PRIVATE rt Threads::Threads PkgConfig::deps)
 
+configure_package_config_file(
+    hyprwayland-scanner-config.cmake.in
+    hyprwayland-scanner-config.cmake
+    INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/hyprwayland-scanner"
+    PATH_VARS CMAKE_INSTALL_BINDIR
+)
+
 # Installation
 install(TARGETS hyprwayland-scanner)
 install(FILES ${CMAKE_BINARY_DIR}/hyprwayland-scanner.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+install(FILES ${CMAKE_BINARY_DIR}/hyprwayland-scanner-config.cmake DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/hyprwayland-scanner)

--- a/hyprwayland-scanner-config.cmake.in
+++ b/hyprwayland-scanner-config.cmake.in
@@ -1,0 +1,15 @@
+@PACKAGE_INIT@
+
+set_and_check(BINDIR "@PACKAGE_CMAKE_INSTALL_BINDIR@")
+
+function(hyprwayland_protocol targets protoName protoPath outputPath)
+    add_custom_command(
+        OUTPUT "${outputPath}/${protoName}.cpp"
+        COMMAND "${BINDIR}/hyprwayland-scanner" "${protoPath}/${protoName}.xml" "${outputPath}"
+    )
+    foreach(target ${targets})
+        target_sources(${target} PRIVATE "${outputPath}/${protoName}.cpp")
+    endforeach()
+endfunction()
+
+check_required_components(hyprwayland-scanner)


### PR DESCRIPTION
This allows us to add wayland protocol dependencies to other cmake-based projects with minimum extra code.

The idea is to move `protocolNew()` definition from hyprland `CMakeLists.txt` to this project and have something like that there:

```cmake
add_executable(Hyprland)

find_package(hyprwayland-scanner REQUIRED)
hyprwayland_protocol(
    Hyprland
    "linux-dmabuf-v1"
    "${WAYLAND_PROTOCOLS}/linux-dmabuf/"
    "${CMAKE_SOURCE_DIR}/protocols"
)
```

BTW the 1st argument of `hyprwayland_protocol()` can actually be a list of targets, not just one