### PR TITLE
cmake: add hpp header as target dependency

### DIFF
--- a/hyprwayland-scanner-config.cmake.in
+++ b/hyprwayland-scanner-config.cmake.in
@@ -9,6 +9,7 @@ function(hyprwayland_protocol targets protoName protoPath outputPath)
     )
     foreach(target ${targets})
         target_sources(${target} PRIVATE "${outputPath}/${protoName}.cpp")
+        target_sources(${target} PRIVATE "${outputPath}/${protoName}.hpp")
     endforeach()
 endfunction()
 


### PR DESCRIPTION
target should depend on protoName.hpp otherwise it'll be a build error in case of deletion of this file