### PR TITLE
Make CMAKE builds arch independent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,7 @@ configure_package_config_file(
 write_basic_package_version_file(
   "hyprwayland-scanner-config-version.cmake"
   VERSION "${VERSION}"
+  ARCH_INDEPENDENT
   COMPATIBILITY AnyNewerVersion)
 
 # Installation


### PR DESCRIPTION
Support architecture independent builds.

https://cmake.org/cmake/help/latest/module/CMakePackageConfigHelpers.html#generating-a-package-version-file