### PR TITLE
core: fix types table size for untyped new_id args

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,10 +2,8 @@
 #include <iostream>
 #include <string>
 #include <fstream>
-#include <format>
 #include <vector>
 #include <algorithm>
-#include <tuple>
 #include <filesystem>
 
 bool waylandEnums = false;
@@ -531,7 +529,8 @@ void parseSource() {
     // dummy
     SOURCE += std::format(R"#(
 static const wl_interface* {}[] = {{ nullptr }};
-)#", DUMMY_TYPE_TABLE_NAME);
+)#",
+                          DUMMY_TYPE_TABLE_NAME);
 
     SOURCE += R"#(
 // Reference all other interfaces.
@@ -781,6 +780,12 @@ void {}::{}({}) {{
             SOURCE += std::format("static const wl_interface* {}[] = {{\n", TYPE_TABLE_NAME);
 
             for (auto& arg : rq.args) {
+                if (arg.wlType == "new_id" && arg.interface.empty()) {
+                    // untyped new_id expands to (string, uint, new_id)
+                    SOURCE += "    nullptr,\n    nullptr,\n    nullptr,\n";
+                    continue;
+                }
+
                 if (arg.interface.empty()) {
                     SOURCE += "    nullptr,\n";
                     continue;
@@ -799,6 +804,12 @@ void {}::{}({}) {{
             SOURCE += std::format("static const wl_interface* {}[] = {{\n", TYPE_TABLE_NAME);
 
             for (auto& arg : ev.args) {
+                if (arg.wlType == "new_id" && arg.interface.empty()) {
+                    // untyped new_id expands to (string, uint, new_id)
+                    SOURCE += "    nullptr,\n    nullptr,\n    nullptr,\n";
+                    continue;
+                }
+
                 if (arg.interface.empty()) {
                     SOURCE += "    nullptr,\n";
                     continue;
@@ -825,7 +836,7 @@ static const wl_message {}[] = {{
                     const auto TYPE_TABLE_NAME = camelize(std::string{"_"} + "C_" + IFACE_NAME + "_" + rq.name + "_types");
 
                     SOURCE += std::format("    {{ .name = \"{}\", .signature = \"{}\", .types = {}}},\n", rq.name, argsToShort(rq.args, rq.since),
-                                          rq.args.empty() ?  std::format("{} + 0", DUMMY_TYPE_TABLE_NAME) : TYPE_TABLE_NAME + " + 0");
+                                          rq.args.empty() ? std::format("{} + 0", DUMMY_TYPE_TABLE_NAME) : TYPE_TABLE_NAME + " + 0");
                 }
 
                 SOURCE += "};\n";


### PR DESCRIPTION
Fixes https://github.com/hyprwm/hyprlock/issues/980

I could not reproduce the issue with the exec built from source, but it was happening with the Arch package (for LTO flag).

Conceptually the issue is clear, though I want to specify that I've used an AI model.
I've reviewed and tested the output, and manually edited the description below trying to make it clear and concise.

Not being an expert with low level memory optimizations is not very clear to me the reason why it didn't happen without LTO flag though.

I hope this is compliant with your AI policies (ref. https://github.com/hyprwm/.github/blob/main/policies/AI_USAGE.md).

---

When `WAYLAND_DEBUG=client` is set, any binary built with LTO that links generated code from `hyprwayland-scanner` segfaults immediately on startup.
This affects hyprlock on Arch Linux (which builds with `-flto=auto` via makepkg.conf).

When a `new_id` argument has no fixed interface (e.g. `wl_registry.bind`), `argsToShort()` correctly expands it to three wire-level characters in the signature: `s` (interface name string), `u` (version uint), `n` (new_id)  producing a signature like `"usun"` (4 characters).

> Personal note: not a wayland expert either, but assuming the first `u` (uint) in the example is required by the protocol.

However, the **types table generator** only emits **one** `nullptr` entry per `<arg>` XML element.
For `wl_registry.bind` this produces a 2-entry array backing a 4-character signature:

> Personal note:
> 2-entry array because of `u` and `sun` being handled as single unit (1+1, wrong)
> 4-entry array because of `u` and `sun` (1+3)

```c
// before (WRONG): 2 entries for "usun" (4 args on the wire)
static const wl_interface* _CWlRegistryBindTypes[] = {
    nullptr,  // name (u)
    nullptr,  // bind's new_id, but wire format is (s, u, n) = 3 slots!
};
```

libwayland's `wl_closure_print` (only called when `WAYLAND_DEBUG` is set) iterates over the signature and dereferences `types[i]` for each character, causing an **out-of-bounds read** past the undersized array.

Without LTO, adjacent zero-filled `.rodata` masks the bug.
With LTO the compiler packs static tables tighter, so the OOB read hits live data... segfault!

The fix emits 3 `nullptr` entries in the types table for untyped `new_id` args, matching the 3 wire-level slots that `argsToShort()` already generates in the signature:

```c
// after (CORRECT): 4 entries for "usun"
static const wl_interface* _CWlRegistryBindTypes[] = {
    nullptr,  // name (u)
    nullptr,  // interface name (s)
    nullptr,  // version (u)
    nullptr,  // new_id (n)
};
```